### PR TITLE
Fix map too dark in dark mode

### DIFF
--- a/arch/v0.3.4/trail-viewer/src/App.jsx
+++ b/arch/v0.3.4/trail-viewer/src/App.jsx
@@ -203,6 +203,7 @@ function App() {
           drawMode={drawMode}
           onSaveDrawnTrail={handleSaveDrawnTrail}
           onCloseDrawMode={() => setDrawMode(false)}
+          theme={theme}
         />
         
         {/* Map Controls - Floating toggle buttons */}

--- a/arch/v0.3.4/trail-viewer/src/components/Map.jsx
+++ b/arch/v0.3.4/trail-viewer/src/components/Map.jsx
@@ -104,7 +104,7 @@ function FitBounds({ bounds, selectedTrack, sidebarOpen }) {
   return null;
 }
 
-export default function Map({ tracks, selectedTrack, onTrackClick, showMileMarkers, showStartFinish, cursorPosition, onMapHover, sidebarOpen, drawMode, onSaveDrawnTrail, onCloseDrawMode }) {
+export default function Map({ tracks, selectedTrack, onTrackClick, showMileMarkers, showStartFinish, cursorPosition, onMapHover, sidebarOpen, drawMode, onSaveDrawnTrail, onCloseDrawMode, theme }) {
   const mapRef = useRef();
   
   // Calculate mile markers for selected track
@@ -301,9 +301,9 @@ export default function Map({ tracks, selectedTrack, onTrackClick, showMileMarke
         ref={mapRef}
       >
         <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          attribution='© OpenStreetMap'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          className="map-tiles grayscale-[0.3] contrast-125 brightness-75"
+          className={theme === 'dark' ? 'brightness-115 contrast-105' : ''}
         />
         
         {tracks.map((track) => (

--- a/arch/v0.3.4/trail-viewer/src/index.css
+++ b/arch/v0.3.4/trail-viewer/src/index.css
@@ -87,7 +87,8 @@
 }
 
 [data-theme="dark"] .leaflet-tile-container {
-  filter: grayscale(0.3) contrast(1.25) brightness(0.75);
+  /* filter: grayscale(0.3) contrast(1.25) brightness(0.75); */
+  filter: brightness(0.90) contrast(1.25) saturate(0.75);
 }
 
 .leaflet-popup-content-wrapper {


### PR DESCRIPTION
Fixes #18

Adjust Leaflet tile CSS filter in dark theme to brighten the map without washing it out.