### PR TITLE
Improve selected track visibility (outline + shadow)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,17 @@
   transition: filter 0.3s ease;
 }
 
+
+/* Selected track styling: make it pop like POI */
+.leaflet-interactive.selected-track-core {
+  filter: drop-shadow(0 3px 10px rgba(0,0,0,0.45));
+}
+
+.leaflet-interactive.selected-track-outline {
+  filter: drop-shadow(0 3px 10px rgba(0,0,0,0.45));
+}
+
+
 [data-theme="light"] .leaflet-container {
   background: #f5f5f5;
 }


### PR DESCRIPTION

## Summary
Improves visibility of the selected trail on the map.

The selected track now renders with:
- white outline (halo)
- green core line
- subtle drop shadow

This makes the active route pop clearly above other trails and tiles (especially terrain/dark themes).

## Changes
- Render selected track as two layers (outline + core)
- Added drop-shadow styling
- Introduced tweakable constants:
  - SELECTED_TRACK_LINE_COLOR
  - SELECTED_TRACK_OUTLINE_COLOR
  - SELECTED_LINE_WEIGHT
  - SELECTED_OUTLINE_WEIGHT

## Result
Better contrast and readability with zero behavior changes.

Closes #32
