### PR TITLE
fix: correctly center map with asymmetric sidebars and animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ function App() {
   const [drawMode, setDrawMode] = useState(false);
   const [isSheetMinimized, setIsSheetMinimized] = useState(false);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isTrackListCollapsed, setIsTrackListCollapsed] = useState(false);
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark');
   const [trackCache, setTrackCache] = useState({});  // Use plain object instead of Map
   const [trackCacheOrder, setTrackCacheOrder] = useState([]); // array of filenames, most-recent at end
@@ -277,11 +278,24 @@ function App() {
       <div className={`
         fixed inset-y-0 left-0 z-[1002] w-80 transform transition-transform duration-300 ease-in-out
         ${isMenuOpen ? 'translate-x-0' : '-translate-x-full'}
-        lg:relative lg:translate-x-0 lg:w-96 lg:h-full border-r border-[var(--border-color)]
+        lg:relative lg:translate-x-0 lg:h-full border-r border-[var(--border-color)]
+        ${isTrackListCollapsed ? 'lg:w-0 lg:opacity-0 lg:overflow-hidden' : 'lg:w-96'}
       `}>
          <button onClick={() => setIsMenuOpen(false)} className="lg:hidden absolute top-4 right-4 z-20 text-[var(--text-secondary)]">
            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
          </button>
+         
+         {/* Collapse button (visible when TrackList is open) */}
+         <button
+            onClick={() => setIsTrackListCollapsed(true)}
+            className="hidden lg:flex absolute -right-10 top-4 z-50 p-2 bg-[var(--bg-secondary)] border border-[var(--border-color)] rounded-r-lg text-[var(--accent-primary)] hover:brightness-110 shadow-md"
+            title="Hide Track List"
+          >
+            <svg className="w-5 h-5 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+         
          <TrackList
             tracks={tracks}
             selectedTrack={selectedTrack}
@@ -290,6 +304,19 @@ function App() {
             loadingTrack={loadingTrack}
           />
       </div>
+
+      {/* Expand TrackList button (visible when TrackList is collapsed) */}
+      {isTrackListCollapsed && (
+        <button
+          onClick={() => setIsTrackListCollapsed(false)}
+          className="hidden lg:flex fixed left-4 top-4 z-[1004] p-2.5 bg-[var(--bg-secondary)] border border-[var(--border-color)] rounded-lg text-[var(--accent-primary)] hover:brightness-110 shadow-lg items-center justify-center"
+          title="Show Track List"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      )}
 
       <div className="flex-1 relative h-full">
         <Map
@@ -307,6 +334,7 @@ function App() {
           theme={theme}
           sidebarOpen={!!selectedTrack && !isSidebarCollapsed}
           isSidebarCollapsed={isSidebarCollapsed}
+          trackListCollapsed={isTrackListCollapsed}
         />
       </div>
 


### PR DESCRIPTION
## Overview
Fixes #60 – Corrects map centering issues caused by sidebar animations and asymmetric layout.

## Problem
The map failed to visually center trails when sidebars were opened or collapsed:
- FitBounds executed before sidebar animations completed
- Bounding-box centering ignored asymmetric padding
- Trails drifted when toggling panels
- TrackList could not be collapsed, limiting map space

## Solution

### 1. Animation-Aware FitBounds
- Introduced a delay when sidebar collapse state changes
- Ensures layout is stable before computing bounds and center
- No delay for initial load or track changes

### 2. True Geometric Centering
- Computes center of mass from all track coordinates
- More accurate centering than bounding-box midpoint
- Especially effective for long or irregular trails

### 3. Asymmetric Padding Compensation
- Accounts for independent left and right sidebar widths
- Computes pixel offset to center trail in visible map area
- Prevents visual bias when only one panel is open

### 4. Two-Stage Centering
1. fitBounds to establish zoom
2. setView to adjusted center-of-mass
- Smooth animations when panels change state

### 5. TrackList Collapse Support
- Added independent collapse/expand for TrackList
- Animated width and opacity transitions
- Expand button shown when collapsed
- Map recenters automatically when TrackList state changes

## User Experience Improvements
- Trails always appear visually centered
- Panels can be collapsed independently for maximum map space
- Smooth, predictable map behavior during UI transitions
- No changes to mobile bottom sheet behavior

## Testing Checklist
- [x] Collapse right sidebar → correct centering
- [x] Collapse TrackList → correct centering
- [x] Collapse both → centered full-width map
- [x] Expand panels → smooth animated recenter
- [x] Track change → always centered
- [x] Mobile behavior unchanged

## Technical Details
- Components: Map.jsx, App.jsx
- Desktop-only behavior (lg breakpoint)
- No breaking changes
- No performance regressions

Closes #60