### PR TITLE
feat: Add peak markers to 3D Cesium view

### DIFF
--- a/public/peaks/peaks.json
+++ b/public/peaks/peaks.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "Mount Whitney",
+    "lat": 36.5785,
+    "lon": -118.2923,
+    "elevation": 14505
+  },
+  {
+    "name": "Mount Baldy",
+    "lat": 34.2894,
+    "lon": -117.6462,
+    "elevation": 10064
+  },
+  {
+    "name": "San Gorgonio Mountain",
+    "lat": 34.0992,
+    "lon": -116.8249,
+    "elevation": 11503
+  },
+
+  {
+    "name": "Ontario Peak",
+    "lat": 34.2278,
+    "lon": -117.6231,
+    "elevation": 8693
+  },
+  {
+    "name": "Etiwanda Peak",
+    "lat": 34.2283,
+    "lon": -117.5725,
+    "elevation": 8662
+  },
+  { "name": "Mt Wilson", "lat": 34.2238, "lon": -118.0616, "elevation": 5713 },
+  {
+    "name": "Strawberry Peak",
+    "lat": 34.2836,
+    "lon": -118.1203,
+    "elevation": 6167
+  },
+  {
+    "name": "Mt Disappointment",
+    "lat": 34.2467,
+    "lon": -118.1048,
+    "elevation": 5963
+  },
+  { "name": "Verdugo Peak", "lat": 34.217, "lon": -118.283, "elevation": 3126 },
+  { "name": "Mt Lukens", "lat": 34.269, "lon": -118.239, "elevation": 5075 },
+  { "name": "Mt Lowe", "lat": 34.2083, "lon": -118.125, "elevation": 5604 }
+]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,9 @@ function App() {
   const [mapMode, setMapMode] = useState(
     () => localStorage.getItem("mapMode") || "2d",
   ); // "2d" | "3d"
+  
+  // ✅ NEW: peaks data for 3D view
+  const [peaks, setPeaks] = useState([]);
 
   // ✅ Ensure Leaflet always receives the selectedTrack in its "tracks" list
   const leafletTracks = (() => {
@@ -98,6 +101,25 @@ function App() {
     }
     // run once
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ✅ NEW: Load peaks data on mount
+  useEffect(() => {
+    const loadPeaks = async () => {
+      try {
+        const response = await fetch(`${import.meta.env.BASE_URL}peaks/peaks.json`);
+        if (!response.ok) {
+          console.warn('Failed to load peaks.json');
+          return;
+        }
+        const data = await response.json();
+        setPeaks(data);
+      } catch (error) {
+        console.error('Error loading peaks:', error);
+      }
+    };
+
+    loadPeaks();
   }, []);
 
   const toggleTheme = () => {
@@ -507,6 +529,7 @@ function App() {
             clampToGround={true}
             showMileMarkers={showMileMarkers}
             cursorIndex={graphHoverIndex}
+            peaks={peaks}
             style={{ width: "100%", height: "100%" }}
           />
         )}


### PR DESCRIPTION
## Summary
This PR adds support for displaying mountain peak markers on the 3D terrain view.

## Changes
- ✅ Added peak marker support to CesiumView component
- ✅ Created Google Maps-style red pin markers with white center
- ✅ Implemented peak data loading from `public/peaks/peaks.json`
- ✅ Added terrain sampling to position markers at correct elevation
- ✅ Markers stay locked to lat/lon coordinates (no camera floating)
- ✅ Added formatted labels showing peak name and elevation
- ✅ Graceful error handling for terrain sampling failures

## Technical Details
- Peak data loaded on app mount via useEffect
- Markers use `sampleTerrainMostDetailed` to get accurate terrain heights
- Positions set using `Cartesian3.fromRadians` with sampled elevation
- No `heightReference` used to prevent camera-relative positioning
- Fallback to ground level (height 0) if terrain sampling fails

## Testing
Tested with sample peaks (Mount Whitney, Mount Baldy, San Gorgonio Mountain) and verified:
- Markers display at correct locations
- Markers stay locked to terrain when panning/zooming
- Labels show correct name and elevation formatting
- Works with and without terrain data

Closes #65