### PR TITLE
feat: Expand 2D elevation graph with smart sidebar behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -618,7 +618,8 @@ function App() {
         )}
       </div>
 
-      {selectedTrack && !isSidebarCollapsed && (
+      {/* ✅ FIX: Always render Sidebar when track selected, but hide container when collapsed */}
+      {selectedTrack && (
         <div
           className={`
   fixed bottom-0 left-0 right-0 w-full z-[1003]
@@ -627,6 +628,7 @@ function App() {
 
   lg:fixed lg:top-0 lg:right-0 lg:bottom-0 lg:left-auto
   lg:w-96 lg:rounded-none lg:border-l border-[var(--border-color)]
+  ${isSidebarCollapsed ? 'lg:translate-x-full' : 'lg:translate-x-0'}
 `}
         >
           <button

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -338,6 +338,22 @@ export default function Sidebar({
     return "h-[85vh]";
   };
 
+  // Expanded graph takes ~370px at bottom (260 chart + 48 header + 36 padding + 24 hint + 2 border)
+  const EXPANDED_GRAPH_HEIGHT = 370;
+  const getSidebarStyle = () => {
+    if (!isDesktop || !isGraphExpanded) return {};
+    return { maxHeight: `calc(100vh - ${EXPANDED_GRAPH_HEIGHT}px)` };
+  };
+
+  // Smart close: if graph expanded, just minimize graph; otherwise close sidebar
+  const handleCloseSidebar = () => {
+    if (isGraphExpanded) {
+      setIsGraphExpanded(false);
+    } else {
+      onClose();
+    }
+  };
+
   const hexToRgba = (hex, a = 0.22) => {
     if (!hex) return `rgba(0,0,0,${a})`;
     const h = hex.replace("#", "").trim();
@@ -396,7 +412,10 @@ export default function Sidebar({
       )}
 
       {/* Main Sidebar */}
-      <div className={`w-full lg:w-96 lg:h-full bg-[var(--bg-secondary)] lg:border-l border-[var(--border-color)] overflow-hidden flex flex-col transition-all duration-300 ${getHeight()} lg:!h-full`}>
+      <div
+        className={`w-full lg:w-96 lg:h-full bg-[var(--bg-secondary)] lg:border-l border-[var(--border-color)] overflow-hidden flex flex-col transition-all duration-300 ${getHeight()} lg:!h-full`}
+        style={getSidebarStyle()}
+      >
         {/* Mobile Drag Handle */}
         <button
           onClick={cycleSnapState}
@@ -438,8 +457,9 @@ export default function Sidebar({
                   )}
                 </button>
                 <button
-                  onClick={onClose}
+                  onClick={handleCloseSidebar}
                   className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors p-1"
+                  title={isGraphExpanded ? "Minimize graph" : "Close sidebar"}
                 >
                   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
## 🎯 Closes #76

## Overview
Adds a full-width expanded elevation graph overlay that appears at the bottom of the screen on desktop, giving users a detailed view of the trail elevation profile without losing access to the map or sidebars.

## ✨ Key Features

### 📊 Expanded Graph Overlay
- **Full-width display**: 370px tall chart spanning entire viewport width
- **Portal rendering**: Uses React `createPortal` to render on `document.body`, escaping sidebar DOM constraints
- **Stays visible**: Graph remains visible even when parent sidebar is collapsed
- **Desktop-only**: Automatically hidden on mobile devices

### 🎛️ Smart Sidebar Behavior
- **Auto-collapse**: Both TrackList and Sidebar automatically slide away when graph expands
- **Auto-shrink**: When visible, sidebars reduce height by 370px to prevent overlap
- **Smart close button**: X button minimizes graph (if expanded) OR closes sidebar (if graph minimized)
- **Configurable**: Auto-collapse can be disabled in `App.jsx` (see commit message)

### 🔍 Zoom & Pan Controls
- Zoom in/out with smart boundaries (min 0.1 mi span, auto-reset at 95% full extent)
- Pan left/right (only visible when zoomed - progressive disclosure)
- Reset button returns to full view
- All controls mirrored from sidebar with consistent UX

### ⌨️ Keyboard Shortcuts
- `+` / `=` : Zoom in
- `-` : Zoom out
- `← →` : Pan left/right (when zoomed)
- `0` / `Esc` : Reset zoom
- Context-aware: disabled when typing in inputs

### 🎨 Grade Overlay Integration
- Grade overlay renders in expanded view (matches sidebar)
- Dedicated ⋮ settings menu in expanded view
- Tooltip shows grade % alongside elevation
- State synchronized between sidebar and expanded views

## 🏗️ Technical Highlights

### State Management
```jsx
// Lifted isGraphExpanded to App.jsx for multi-component coordination
const [isGraphExpanded, setIsGraphExpanded] = useState(false);
```

### Portal Architecture
```jsx
// ExpandedGraphOverlay renders outside sidebar DOM
return createPortal(
  <div className="fixed inset-x-0 bottom-0 z-[2000]">{/* ... */}</div>,
  document.body
);
```

### Dynamic Height Calculations
Both TrackList and Sidebar shrink by 370px when graph is expanded:
```jsx
const getSidebarStyle = () => {
  if (!isDesktop || !isGraphExpanded) return {};
  return { maxHeight: `calc(100vh - 370px)` };
};
```

## 📁 Files Changed
- `src/App.jsx` - State management, auto-collapse logic
- `src/components/Sidebar.jsx` - Portal rendering, shrink logic
- `src/components/TrackList.jsx` - Shrink behavior

## ✅ Testing Completed
- [x] Expand/minimize on desktop
- [x] Auto-collapse both sidebars
- [x] Sidebar shrink behavior
- [x] Zoom/pan controls
- [x] Keyboard shortcuts
- [x] Grade overlay
- [x] Portal rendering survives sidebar collapse
- [x] Mobile responsiveness
- [x] Dark/light themes

## 💡 Design Rationale

1. **Auto-collapse**: Maximizes screen space for the detailed graph view
2. **Portal escape**: Ensures graph stays visible regardless of sidebar state
3. **Progressive disclosure**: Pan buttons only appear when needed
4. **Keyboard-first**: Power users can control everything without mouse
5. **Configurable**: Easy to disable auto-collapse if users prefer different behavior

## 🚀 Performance
- No performance impact - portal rendering is a native React optimization
- Lazy rendering - expanded view only renders when opened
- Shared state prevents duplicate computation

## 🔄 Breaking Changes
None - purely additive feature

## 📝 Configuration Note
To disable auto-collapse behavior, comment out lines 667-670 in `src/App.jsx`:
```jsx
// if (expanded) {
//   setIsSidebarCollapsed(true);
//   setIsTrackListCollapsed(true);
// }
```

## 🎬 Demo
The expanded graph provides a full-width, detailed view of elevation data with:
- Synchronized zoom/pan state with sidebar
- Grade overlay support
- Smart auto-collapse of both sidebars
- Keyboard shortcuts for power users
- Portal rendering that survives sidebar collapse

This feature significantly improves the UX for analyzing trail elevation profiles on desktop while maintaining full mobile compatibility.