### PR TITLE
feat: Dynamic GPS positioning and build info display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -164,6 +164,23 @@ function App() {
     setTheme((prevTheme) => (prevTheme === "dark" ? "light" : "dark"));
   };
 
+  // At top of App component, before the return
+  const getGpsButtonBottom = () => {
+    if (typeof window === 'undefined') return '80px';
+
+    const ua = window.navigator.userAgent.toLowerCase();
+    const isSafari = ua.includes('safari') && !ua.includes('chrome') && !ua.includes('crios') && !ua.includes('fxios');
+
+    // Desktop
+    if (window.innerWidth >= 1024) return '24px';
+
+    // Mobile Safari needs extra space
+    if (isSafari) return '120px';
+
+    // Mobile Brave/Chrome/Firefox
+    return '80px';
+  };
+
   const loadManifest = async () => {
     try {
       const url = `${import.meta.env.BASE_URL}tracks/manifest.json`;
@@ -663,9 +680,7 @@ function App() {
         {mapMode === "2d" && (
           <div
             className="absolute right-4 z-[1003]"
-            style={{
-              bottom: 'max(24px, env(safe-area-inset-bottom, 24px))'  // Respects iOS notch/toolbar
-            }}
+            style={{ bottom: getGpsButtonBottom() }}
           >
             <GpsButton
               status={gpsStatus}


### PR DESCRIPTION
## 🎯 Closes #84 (part of #83)

## Summary
Fixes GPS button visibility on iOS Safari and adds build timestamp to verify deployed versions.

## 🔧 Changes

### 1. Dynamic GPS Button Positioning
**Problem:** GPS button hidden behind iOS Safari toolbar

**Solution:** Browser-specific positioning with JavaScript detection
- Safari iOS: 120px from bottom (clears dynamic toolbar)
- Brave/Chrome iOS: 80px from bottom (already working)
- Desktop: 24px from bottom (original position)

**Implementation:**
````jsx
const getGpsButtonBottom = () => {
  const ua = window.navigator.userAgent.toLowerCase();
  const isSafari = ua.includes("safari") && !ua.includes("chrome") && 
                   !ua.includes("crios") && !ua.includes("fxios");
  
  if (window.innerWidth >= 1024) return "24px";  // Desktop
  if (isSafari) return "120px";  // Safari iOS needs extra space
  return "80px";  // Brave/Chrome/Firefox iOS
};
````

**Why not CSS?** 
- CSS `@supports (-webkit-touch-callout)` detects ALL WebKit browsers
- Would incorrectly affect Brave (which already works at 80px)
- JS detection allows surgical Safari-only fix

### 2. Build Info Display
**Problem:** Unable to verify deployed version (cache confusion)

**Solution:** Auto-generated build timestamp in TrackList header

**Format:** `Build: 20260220.005704` (yyyymmdd.hhmmss)

**Files:**
- `generate-build-info.js` - Prebuild script
- `src/build-info.js` - Auto-generated metadata
- `package.json` - Added prebuild hook

## 📁 Files Changed

### Added
- `generate-build-info.js` - Build timestamp generator
- `src/build-info.js` - Generated metadata
- `BUILD-INFO-SETUP.md` - Documentation

### Modified  
- `src/App.jsx` - GPS button positioning logic
- `src/components/TrackList.jsx` - Build info display
- `package.json` - Prebuild script

## 🧪 Testing

### iOS Browsers
- [x] Safari: Button visible at all zoom levels (50%-100%)
- [x] Safari: Button clears toolbar when scrolling
- [x] Brave: Still works at 80px (unchanged)
- [x] Chrome iOS: Works at 80px

### Desktop
- [x] All browsers: 24px from bottom (original)
- [x] No layout shifts

### Build Info
- [x] Displays in TrackList header
- [x] Updates on each build
- [x] Visible in dark/light themes

## 🔗 Related
- Parent: #83 - UX update: make buttons show better
- Closes: #84 - Add build info

## 📝 Technical Notes

Safari iOS has unique toolbar behavior:
- Toolbar dynamically appears/disappears on scroll
- `env(safe-area-inset-bottom)` only accounts for static UI (notch)
- Need extra clearance (120px) for dynamic toolbar
- Brave uses Chromium engine, behaves differently (80px works)

User Agent detection targets Safari specifically:
````js
ua.includes("safari") && !ua.includes("chrome") && 
!ua.includes("crios") && !ua.includes("fxios")
```